### PR TITLE
Fix #27: Add "Read More" link to blog previews

### DIFF
--- a/css/homeStyles.css
+++ b/css/homeStyles.css
@@ -26,3 +26,14 @@
 	max-height: 100%;
 }
 
+.read-more {
+	color: #007bff;
+	font-weight: bold;
+	cursor: pointer;
+	text-decoration: underline;
+}
+
+.read-more:hover {
+	color: #0056b3;
+}
+

--- a/js/blogsScript.js
+++ b/js/blogsScript.js
@@ -1,35 +1,43 @@
-import { getFirestore, collection, getDocs } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-firestore.js'
-import app from './firebaseSetup.js'
-const firestore = getFirestore(app)
-const blogs = document.querySelector('#blogs')
-const loadingIndicator = document.querySelector('#loadingContainer')
+import {
+  getFirestore,
+  collection,
+  getDocs,
+} from "https://www.gstatic.com/firebasejs/12.0.0/firebase-firestore.js";
+import app from "./firebaseSetup.js";
+const firestore = getFirestore(app);
+const blogs = document.querySelector("#blogs");
+const loadingIndicator = document.querySelector("#loadingContainer");
 
+// Function to truncate text beyond 50 chars and add "Read More" link
+function truncateText(text, maxLength = 50) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return (
+    text.substring(0, maxLength) +
+    '... <span class="read-more">Read More</span>'
+  );
+}
 
-async function getBlogs () {
-		const querySnapshot = await getDocs(collection(firestore, "blogsRef"))
-		 querySnapshot.forEach((doc) => {
-			const docData = doc.data()
-			blogs.innerHTML += `<a class="blog" id="${doc.id}" href="/viewBlog?blogId=${docData.blogId}"><img class="blogImage" src="./assets/placeholderImage.jpg"><h3>${docData.title}</h3><p>${docData.subline}</p></a>`
-		
-		
-
-	  
-		 })
-	hideLoadingIndicator()
-	console.log('hi')
-
-
-
+async function getBlogs() {
+  const querySnapshot = await getDocs(collection(firestore, "blogsRef"));
+  querySnapshot.forEach((doc) => {
+    const docData = doc.data();
+    const truncatedSubline = truncateText(docData.subline);
+    blogs.innerHTML += `<a class="blog" id="${doc.id}" href="/viewBlog?blogId=${docData.blogId}"><img class="blogImage" src="./assets/placeholderImage.jpg"><h3>${docData.title}</h3><p>${truncatedSubline}</p></a>`;
+  });
+  hideLoadingIndicator();
+  console.log("hi");
 }
 
 try {
-	getBlogs()
-	hideLoadingIndicator()
-} catch(error) {
-	console.log(error)
+  getBlogs();
+  hideLoadingIndicator();
+} catch (error) {
+  console.log(error);
 }
 function hideLoadingIndicator() {
-	loadingIndicator.style.display = 'none'
-	console.log('l')
-	loadingIndicator.style.visibility = 'hidden'
+  loadingIndicator.style.display = "none";
+  console.log("l");
+  loadingIndicator.style.visibility = "hidden";
 }


### PR DESCRIPTION
**Changes Made**

**Files Modified:**

- js/blogsScript.js - Added text truncation functionality
- css/homeStyles.css - Added styling for "Read More" links

**Implementation Details**:
JavaScript Changes (js/blogsScript.js):

- Added truncateText() function that limits blog descriptions to 50 characters
- Automatically appends "... Read More" when text exceeds the character limit
- Applied truncation to all blog sublines before rendering

CSS Changes (css/homeStyles.css):

- Added .read-more class styling with blue color (#007bff) and bold font weight
- Included hover effect that darkens the link color (#0056b3) on mouse over
- Added underline decoration and pointer cursor for better UX