### PR TITLE
Fix #14: Enable showing "No blogs found"

### DIFF
--- a/css/homeStyles.css
+++ b/css/homeStyles.css
@@ -37,3 +37,10 @@
 	color: #0056b3;
 }
 
+.no-blogs {
+	text-align: center;
+	font-size: 1.2rem;
+	color: #666;
+	margin: 2rem auto;
+	width: 100%;
+}

--- a/js/blogsScript.js
+++ b/js/blogsScript.js
@@ -21,11 +21,16 @@ function truncateText(text, maxLength = 50) {
 
 async function getBlogs() {
   const querySnapshot = await getDocs(collection(firestore, "blogsRef"));
-  querySnapshot.forEach((doc) => {
-    const docData = doc.data();
-    const truncatedSubline = truncateText(docData.subline);
-    blogs.innerHTML += `<a class="blog" id="${doc.id}" href="/viewBlog?blogId=${docData.blogId}"><img class="blogImage" src="./assets/placeholderImage.jpg"><h3>${docData.title}</h3><p>${truncatedSubline}</p></a>`;
-  });
+  if (querySnapshot.empty) {
+    blogs.innerHTML =
+      "<p class='no-blogs'>No blogs found, Be the first to create one!</p>";
+  } else {
+    querySnapshot.forEach((doc) => {
+      const docData = doc.data();
+      const truncatedSubline = truncateText(docData.subline);
+      blogs.innerHTML += `<a class="blog" id="${doc.id}" href="/viewBlog?blogId=${docData.blogId}"><img class="blogImage" src="./assets/placeholderImage.jpg"><h3>${docData.title}</h3><p>${truncatedSubline}</p></a>`;
+    });
+  }
   hideLoadingIndicator();
   console.log("hi");
 }


### PR DESCRIPTION
**Changes Made**

Files Modified:
- js/blogsScript.js - Added empty state handling
- css/homeStyles.css - Added styling for "No blogs found" message

**Implementation Details**
JavaScript Changes (js/blogsScript.js):
- Added if (querySnapshot.empty) check to detect when Firestore returns no blogs
- Displays user-friendly message: "No blogs found, Be the first to create one!" when collection is empty
- Maintains existing functionality for when blogs are present

CSS Changes (css/homeStyles.css):
Added .no-blogs class styling with:
- Centered text alignment
- Larger font size (1.2rem) for better visibility
- Gray color (#666) for subtle appearance
- Proper margin spacing (2rem auto)
- Full width to ensure proper centering

Solves Issue #14
<img width="1915" height="147" alt="no-blogs-ss" src="https://github.com/user-attachments/assets/f16368c4-2086-43a2-942e-fff3c6bc10eb" />
