### PR TITLE
feat: Add cover image upload for blogs

### DIFF
--- a/createBlog.html
+++ b/createBlog.html
@@ -11,7 +11,6 @@
 	<link rel="stylesheet" href="css/darkMode.css">
 	<link rel="stylesheet" href="css/darkModeCreateBlog.css">
 	<link rel="icon" type="image/png" href="assets/favicon.ico">
-	<!-- Insert this script at the bottom of the HTML, but before you use any Firebase services -->
 	<script src="js/markdownParser.js" defer></script>
 	<script src="js/firebaseSetup.js" defer type="module"></script>
 	<script src="js/script.js" defer type="module"></script>
@@ -37,7 +36,6 @@
 	</div>
 
 
-	<!-- Step 1: Blog Details Form -->
 	<div id="blogDetailsStep" class="step-container active">
 		<div class="step-header">
 			<h1>Create New Blog</h1>
@@ -53,6 +51,11 @@
 			<div class="form-group">
 				<label for="subtitle">Subtitle *</label>
 				<input type="text" id="subtitle" name="subtitle" required placeholder="Enter your blog subtitle">
+			</div>
+
+			<div class="form-group">
+				<label for="coverImage">Cover Image</label>
+				<input type="file" id="coverImage" name="coverImage" accept="image/*">
 			</div>
 
 			<div class="form-row">
@@ -127,7 +130,6 @@
 		</form>
 	</div>
 
-	<!-- Step 2: Blog Body Editor -->
 	<div id="blogBodyStep" class="step-container">
 		<div class="editor-header">
 			<div class="editor-nav">
@@ -141,7 +143,6 @@
 
 		<div class="editor-container">
 			<div class="editor-toolbar">
-				<!-- Text Formatting -->
 				<button type="button" class="toolbar-btn" data-md="bold" title="Bold">
 					<strong>B</strong>
 				</button>
@@ -158,7 +159,6 @@
 
 				<div class="toolbar-separator"></div>
 
-				<!-- Headers -->
 				<button type="button" class="toolbar-btn" data-md="h1" title="Heading 1">
 					H1
 				</button>
@@ -171,7 +171,6 @@
 
 				<div class="toolbar-separator"></div>
 
-				<!-- Lists -->
 				<button type="button" class="toolbar-btn" data-md="ul" title="Bullet List">
 					⏺
 				</button>
@@ -183,7 +182,6 @@
 				<div class="toolbar-separator"></div>
 
 
-				<!-- Links -->
 				<button type="button" class="toolbar-btn" data-md="link" title="Insert Link">
 					🔗
 				</button>
@@ -191,7 +189,6 @@
 
 				<div class="toolbar-separator"></div>
 
-				<!-- Other -->
 				<button type="button" class="toolbar-btn" data-md="quote" title="Quote">
 					"
 				</button>
@@ -205,7 +202,6 @@
 
 				<div class="toolbar-separator"></div>
 
-				<!-- Preview Button -->
 				<button type="button" id="previewBtn" class="toolbar-btn preview-btn" title="Preview Blog">
 					👁️ Preview
 
@@ -221,7 +217,6 @@
 
 
 
-			<!-- Markdown input dialogs -->
 			<div id="linkDialog" class="md-dialog" style="display: none;">
 				<div class="md-dialog-content">
 					<h3>Insert Link</h3>
@@ -247,7 +242,6 @@
 		</div>
 	</div>
 
-	<!-- Preview Modal -->
 	<div id="previewModal" class="preview-modal" style="display: none;">
 		<div class="preview-modal-content">
 			<div class="preview-header">
@@ -256,8 +250,7 @@
 			</div>
 			<div class="preview-body">
 				<div id="previewContent" class="preview-content">
-					<!-- Rendered markdown content will be inserted here -->
-				</div>
+					</div>
 			</div>
 		</div>
 	</div>
@@ -285,7 +278,6 @@
 
 		<p id="metis">Made with ❤️ by Metis, IITGN</p>
 
-		<!-- Back to Top Button -->
 		<button id="backToTop" class="back-to-top" aria-label="Back to top">
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
 				stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -294,10 +286,8 @@
 		</button>
 	</div>
 
-	<!-- Back to Top Script -->
 	<script src="js/back-to-top.js" defer></script>
 
-	<!-- Toast Notification -->
 	<div id="toast" class="toast">
 		<div class="toast-content">
 			<span class="toast-message">Blog posted successfully!</span>

--- a/js/blogsScript.js
+++ b/js/blogsScript.js
@@ -36,9 +36,11 @@ function renderBlog(doc) {
   }
   
   const truncatedSubline = truncateText(subline);
+  const imageUrl = docData.imageUrl || './assets/placeholderImage.jpg'; // Use uploaded image or placeholder
+
   const blogHTML = `
     <a class="blog" id="${doc.id}" href="viewBlog.html?blogId=${docData.blogId}">
-      <img class="blogImage" src="./assets/placeholderImage.jpg" alt="${docData.title}">
+      <img class="blogImage" src="${imageUrl}" alt="${docData.title}">
       <div class="blog-content">
         <h3>${title}</h3>
         <p>${truncatedSubline}</p>

--- a/js/viewBlogScript.js
+++ b/js/viewBlogScript.js
@@ -11,6 +11,7 @@ const subline = document.querySelector('#subline')
 const author = document.querySelector('#author')
 const blogDate = document.querySelector('#blogDate')
 const body = document.querySelector('#body')
+const blogImage = document.querySelector('#blogImage');
 const deleteButton = document.getElementById('deleteButton')
 const deleteDialog = document.getElementById('deleteDialog')
 const confirmDeleteBtn = document.getElementById('confirmDelete')
@@ -109,6 +110,13 @@ async function loadBlog() {
       blogTitle.textContent = blogData.title || 'Untitled'
       subline.textContent = blogData.subtitle || ''
       author.textContent = `By ${blogData.author || 'Unknown Author'}`
+
+      // Display the blog image if it exists
+      if (blogData.imageUrl) {
+        blogImage.src = blogData.imageUrl;
+        blogImage.alt = blogData.title; // Use blog title for alt text
+        blogImage.style.display = 'block';
+      }
       
       // Parse and display blog content
       const contentType = blogData.contentType || 'html';

--- a/viewBlog.html
+++ b/viewBlog.html
@@ -11,7 +11,6 @@
     <link rel="stylesheet" href="css/darkModeViewBlog.css">
 
     <link rel="icon" type="image/png" href="assets/favicon.ico">
-  <!-- Insert this script at the bottom of the HTML, but before you use any Firebase services -->
   <script src="js/firebaseSetup.js" defer type="module"></script>
   <script src="js/script.js" defer type="module"></script>
   <script src="js/markdownParser.js" defer></script>
@@ -19,7 +18,6 @@
   <script src="js/darkMode.js" defer></script>
   </head>
   <body>
-    <!-- Delete Confirmation Dialog -->
     <div id="deleteDialog" class="dialog-overlay" hidden>
       <div class="dialog">
         <h3>Delete Blog Post</h3>
@@ -52,6 +50,7 @@
         <header>
           <h1 id="title"></h1>
           <p id="subline" class="subline"></p>
+          <img id="blogImage" src="" alt="" style="display: none; max-width: 100%; border-radius: 8px; margin: 1.5rem 0;">
           <div class="blog-meta">
             <span id="author" class="author"></span>
             <span id="blogDate" class="date"></span>
@@ -88,16 +87,14 @@
     
     <p id="metis">Made with ❤️ by Metis, IITGN</p>
     
-    <!-- Back to Top Button -->
     <button id="backToTop" class="back-to-top" aria-label="Back to top">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24" fill="none"
         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M18 15l-6-6-6 6" />
       </svg>
     </button>    
   </div>
 
-  <!-- Back to Top Script -->
   <script src="js/back-to-top.js" defer></script>
 
   </body>


### PR DESCRIPTION
Adds a file input on the create blog page to allow users to upload a cover image. The image is stored in Firebase Storage, and its URL is saved to the Firestore document. The image is displayed on the blog view page and homepage cards.